### PR TITLE
[AMQP Adapter] Keep behaviour consistent between first and subsequent publishes

### DIFF
--- a/lib/adapters/amqp.js
+++ b/lib/adapters/amqp.js
@@ -95,7 +95,7 @@ function createdConnection(config) {
 }
 
 function whenConnectionReady(connection, fn) {
-  if (connection.readyEmitted) return fn();
+  if (connection.readyEmitted) return process.nextTick(fn);
   connection.once('ready', fn);
 }
 


### PR DESCRIPTION
A publish should always end at least on `process.nextTick()`
