### PR TITLE
Revert responder collaboration

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,6 @@ An requester is a collector component that can also publish new messages on the 
 - **options.ackTimeout** Optional Rquester will wait at least this amount of milliseconds for acks, before ending this request.
 - **options.responseTimeout** Optional Milliseconds before ending this request. (Default: 3000).
 - **options.waitForResponses** Optional Number of responses the collector expects before either ending or timing out. (Default: Infinity/-1, i.e. only end on timeout. You will typically set this to 1.)
-- **options.collaboration** String Topic name where responses should be published for further collaboration by other responders.
 - **originalMessage** Optional (Object|null) Message this request should correlate with. If `null` it will override current `messageFactory` context for correlation.
 
 #### requester.publish([payload][, cb])

--- a/lib/messageFactory.js
+++ b/lib/messageFactory.js
@@ -14,7 +14,6 @@ messageFactory.createBaseMessage = function(originalMessage) {
   var message = {
     id: generateId(), // This identifies this message
     correlationId: (originalMessage && originalMessage.correlationId) || generateId(), // This identifies this flow
-    collaborationId: null,
     topics: {},
     meta: null, // To be filled with createMeta() -> completeMeta() sequence
     ack: null, // To be filled on ack or response
@@ -45,9 +44,6 @@ messageFactory.createRequestMessage = function(config, originalMessage) {
   var message = messageFactory.createDirectedMessage(config, originalMessage);
 
   message.topics.response = config.namespace + ':response:' + INSTANCE_ID;
-  if (config.collaboration) {
-    message.topics.collaboration = config.collaboration;
-  }
 
   return message;
 };
@@ -55,20 +51,8 @@ messageFactory.createRequestMessage = function(config, originalMessage) {
 messageFactory.createResponseMessage = function(originalMessage, ack, payload) {
   var message = messageFactory.createBaseMessage(originalMessage);
 
-  message.collaborationId = originalMessage.collaborationId;
   message.topics.to = originalMessage.topics.response;
   message.ack = ack;
-  message.payload = payload;
-
-  return message;
-};
-
-messageFactory.createCollaborationMessage = function(originalMessage, payload) {
-  var message = messageFactory.createBaseMessage(originalMessage);
-
-  message.collaborationId = generateId();
-  message.topics.to = originalMessage.topics.collaboration;
-  message.topics.response = originalMessage.topics.response;
   message.payload = payload;
 
   return message;

--- a/lib/responder.js
+++ b/lib/responder.js
@@ -1,7 +1,6 @@
 'use strict';
 var EventEmitter = require('events').EventEmitter;
 var _ = require('lodash');
-var async = require('async');
 var channelManager = require('./channelManager');
 var messageFactory = require('./messageFactory');
 var ResponderServer = require('./responderServer');
@@ -42,18 +41,8 @@ responder.sendAckWithTimeout = responder.sendAck; // Backward-compatibility
 
 responder.send = function(payload, cb) {
   this.ack.responsesRemaining = -1;
-
-  var responseMessage = messageFactory.createResponseMessage(this.originalMessage, this.ack, payload);
-  var responseIsPartOfCollaboration = this.originalMessage.topics.collaboration;
-  var collaborationExists = this.originalMessage.collaborationId;
-
-  if (!responseIsPartOfCollaboration || collaborationExists) {
-    return this._sendMessage(responseMessage, cb);
-  }
-
-  var collaborationMessage = messageFactory.createCollaborationMessage(this.originalMessage, payload);
-  responseMessage.collaborationId = collaborationMessage.collaborationId;
-  async.each([responseMessage, collaborationMessage], this._sendMessage.bind(this), cb);
+  var message = messageFactory.createResponseMessage(this.originalMessage, this.ack, payload);
+  this._sendMessage(message, cb);
 };
 
 responder._sendMessage = function(message, cb) {

--- a/test/responder.test.js
+++ b/test/responder.test.js
@@ -58,7 +58,7 @@ describe('Responder', function() {
     var responder;
 
     beforeEach(function(done) {
-      responder = new Responder({}, { topics: { ack: 'ack' } });
+      responder = new Responder({}, { topics: { response: 'response' } });
 
       simple.mock(responder, '_sendMessage').returnWith();
 
@@ -180,11 +180,9 @@ describe('Responder', function() {
     var mockChannel;
 
     beforeEach(function(done) {
-      responder = new Responder({}, { topics: { ack: 'ack' } });
+      responder = new Responder({}, { topics: { response: 'response' } });
 
-      mockChannel = {};
-      simple.mock(mockChannel, 'publish');
-      simple.mock(channelManager, 'findOrCreateProducer').returnWith(mockChannel);
+      simple.mock(responder, '_sendMessage');
 
       done();
     });
@@ -195,7 +193,7 @@ describe('Responder', function() {
     var mockChannel;
 
     beforeEach(function(done) {
-      responder = new Responder({}, { topics: { ack: 'ack' } });
+      responder = new Responder({}, { topics: { response: 'response' } });
 
       mockChannel = {};
       simple.mock(mockChannel, 'publish');

--- a/test/responder.test.js
+++ b/test/responder.test.js
@@ -180,67 +180,13 @@ describe('Responder', function() {
     var mockChannel;
 
     beforeEach(function(done) {
-      responder = new Responder({}, { topics: { response: 'response' } });
+      responder = new Responder({}, { topics: { ack: 'ack' } });
 
-      simple.mock(responder, '_sendMessage');
+      mockChannel = {};
+      simple.mock(mockChannel, 'publish');
+      simple.mock(channelManager, 'findOrCreateProducer').returnWith(mockChannel);
 
       done();
-    });
-
-    describe('for collaborations', function() {
-      beforeEach(function(done) {
-        responder.originalMessage.topics.collaboration = 'collabt';
-
-        done();
-      });
-
-      it('can initiate a collaboration', function(done) {
-        var payload = {};
-
-        responder._sendMessage.callbackWith();
-
-        responder.send(payload, function(err) {
-          if (err) return done(err);
-
-          expect(responder._sendMessage.callCount).equals(2);
-
-          var firstMessage = responder._sendMessage.calls[0].arg;
-          expect(firstMessage.collaborationId).string();
-          expect(firstMessage.topics.to).equals('response');
-          expect(firstMessage.payload).equals(payload);
-
-          var secondMessage = responder._sendMessage.calls[1].arg;
-          expect(secondMessage.topics.to).equals('collabt');
-          expect(secondMessage.topics.response).equals('response');
-          expect(secondMessage.payload).equals(payload);
-
-          expect(firstMessage.collaborationId).equals(secondMessage.collaborationId);
-
-          done();
-        });
-      });
-
-      it('can respond as part of a collaboration', function(done) {
-        var payload = {};
-
-        responder.originalMessage.collaborationId = 'abc123';
-
-        responder._sendMessage.callbackWith();
-
-        responder.send(payload, function(err) {
-          if (err) return done(err);
-
-          expect(responder._sendMessage.callCount).equals(1);
-
-          var lastMessage = responder._sendMessage.lastCall.arg;
-          expect(lastMessage.collaborationId).equals(responder.originalMessage.collaborationId);
-          expect(lastMessage.topics.to).equals('response');
-          expect(lastMessage.payload).equals(payload);
-
-          done();
-        });
-      });
-
     });
   });
 
@@ -249,7 +195,7 @@ describe('Responder', function() {
     var mockChannel;
 
     beforeEach(function(done) {
-      responder = new Responder({}, { topics: { response: 'response' } });
+      responder = new Responder({}, { topics: { ack: 'ack' } });
 
       mockChannel = {};
       simple.mock(mockChannel, 'publish');


### PR DESCRIPTION
After testing the need for this feature, we've decided that the additional complexity is better handled in individual implementation than on the framework level.

Reverts tcdl/msb#11
