### PR TITLE
Changed requester to only publish once the response channel is consuming

### DIFF
--- a/lib/adapters/amqp/subscriber.js
+++ b/lib/adapters/amqp/subscriber.js
@@ -13,6 +13,7 @@ function AMQPSubscriber(config, connection) {
   this._onSelfError = this._onSelfError.bind(this);
   this._onConsumerError = this._onConsumerError.bind(this);
   this._ensureConsuming = this._ensureConsuming.bind(this);
+  this._emitConsuming = this._emitConsuming.bind(this);
 
   this.on('error', this._onSelfError);
   this._init();
@@ -28,6 +29,11 @@ subscriber.close = function() {
   this.isClosed = true;
   this.connection.removeListener('ready', this._ensureConsuming);
   if (this.consumer) this.consumer.close();
+};
+
+subscriber.onceConsuming = function(cb) {
+  if (this.consumer && this.consumer.consumerState === 'open') return cb();
+  this.once('consuming', cb);
 };
 
 subscriber._init = function() {
@@ -59,6 +65,10 @@ subscriber._onConsumerError = function(err) {
   this.emit('error', err);
 };
 
+subscriber._emitConsuming = function() {
+  this.emit('consuming');
+};
+
 subscriber._ensureConsuming = function() {
   var self = this;
   var config = self.config;
@@ -81,9 +91,9 @@ subscriber._ensureConsuming = function() {
         if (self.isClosed) return; // Skip if already closed
 
         if (consumer) {
-          consumer.resume();
+          consumer.resume(self._emitConsuming);
         } else {
-          consumer = self.consumer = connection.consume(queueOptions.queue, queueOptions, self._onMessage);
+          consumer = self.consumer = connection.consume(queueOptions.queue, queueOptions, self._onMessage, self._emitConsuming);
           consumer.on('error', self._onConsumerError);
         }
       });

--- a/lib/channelManager.js
+++ b/lib/channelManager.js
@@ -69,6 +69,11 @@ channelManager.findOrCreateConsumer = function(topic, options) {
   channel.raw = channelManager.createRawConsumer(topic, options);
   channel.setMaxListeners(0);
 
+  channel.onceConsuming = function(cb) {
+    if (!channel.raw.onceConsuming) return cb();
+    channel.raw.onceConsuming(cb);
+  };
+
   function onMessage(message) {
     if (messageHasExpired(message)) return;
     channelManager.emit(channelManager.CONSUMER_NEW_MESSAGE_EVENT, topic);

--- a/lib/requester.js
+++ b/lib/requester.js
@@ -20,19 +20,25 @@ util.inherits(Requester, Collector);
 var requester = Requester.prototype;
 
 requester.publish = function(payload) {
-  var self = this;
-
   if (payload) {
     this.message.payload = payload;
   }
 
-  if (self.waitForResponses) {
+  if (this.waitForResponses) {
     // Bind it here should you want to override it on an instance
     this.shouldAcceptMessageFn = this.shouldAcceptMessageFn.bind(this);
-    self.listenForResponses(self.message.topics.response, self.shouldAcceptMessageFn);
+    this.listenForResponses(this.message.topics.response, this.shouldAcceptMessageFn);
   }
 
   messageFactory.completeMeta(this.message, this.meta);
+
+  if (!this.responseChannel) return this._publish();
+  this.responseChannel.onceConsuming(this._publish.bind(this));
+  return this;
+};
+
+requester._publish = function() {
+  var self = this;
 
   channelManager
   .findOrCreateProducer(self.message.topics.to, this.requestChannelTimeoutMs)


### PR DESCRIPTION
When the response roundtrip is faster than the time it takes to set up the consumer, the response could be missed. This fix will ensure that the requester publishes only once it knows that it is ready to consume a response.
