### PR TITLE
Fix collector events firing after end

### DIFF
--- a/lib/collector.js
+++ b/lib/collector.js
@@ -60,6 +60,7 @@ collector.listenForResponses = function(topic, shouldAcceptMessageFn) {
 
 collector.removeListeners = function() {
   if (this.responseChannel) this.responseChannel.removeListener('message', this._onResponseMessage);
+  this.removeAllListeners();
 };
 
 collector.cancel = function() {
@@ -69,8 +70,8 @@ collector.cancel = function() {
 };
 
 collector.end = function() {
-  this.cancel();
   this.emit('end');
+  this.cancel();
 };
 
 collector.enableTimeout = function() {

--- a/lib/request.js
+++ b/lib/request.js
@@ -33,8 +33,8 @@ module.exports = function(options, payload, cb) {
 
   requester
   .on('response', onResponseFn)
-  .once('error', cb)
-  .once('end', function() {
+  .on('error', cb)
+  .on('end', function() {
     cb(null, responsePayload, responseMessage);
   });
 


### PR DESCRIPTION
When the collector has ended, all listeners should be removed.
