### PR TITLE
Add functional tests with fix for adjusting ack-extended timeout

### DIFF
--- a/lib/collector.js
+++ b/lib/collector.js
@@ -132,18 +132,18 @@ collector._onResponseMessage = function(shouldAcceptMessageFn, message) {
 collector._processAck = function(ack) {
   if (!ack) return; // `null` ack is valid
 
-  if ('timeoutMs' in ack) {
-    var newTimeoutMs = this._setTimeoutMsForResponderId(ack.responderId, ack.timeoutMs);
-    if (newTimeoutMs !== null) {
-      var prevTimeoutMs = this._currentTimeoutMs;
-
-      this._currentTimeoutMs = this._getMaxTimeoutMs();
-      if (prevTimeoutMs !== this._currentTimeoutMs) this.enableTimeout();
-    }
-  }
-
   if ('responsesRemaining' in ack) {
     this._setResponsesRemainingForResponderId(ack.responderId, ack.responsesRemaining);
+  }
+
+  if ('timeoutMs' in ack) {
+    this._setTimeoutMsForResponderId(ack.responderId, ack.timeoutMs);
+  }
+
+  var newTimeoutMs = this._getMaxTimeoutMs();
+  if (newTimeoutMs !== this._currentTimeoutMs) {
+    this._currentTimeoutMs = newTimeoutMs;
+    this.enableTimeout();
   }
 };
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "test": "npm run test-no-publish && if [ -n \"${TRAVIS_TAG}\" ]; then npm run npmrc && npm publish; fi",
     "test-no-publish": "lab -t 95",
     "test-watch": "nodemon node_modules/lab/bin/lab -cv -t 90",
+    "test-watch-functional": "nodemon node_modules/lab/bin/lab -vP functional",
     "cs": "jscs **/*.js -x",
     "capture": "bin/msb -t test:aggregator,test:general --pretty false | bin/msb-save examples/messages"
   },
@@ -24,6 +25,7 @@
     "code": "^1.4.0",
     "jscs": "^1.12.0",
     "lab": "^5.5.0",
+    "msb-test-utils": "^2.0.0",
     "nodemon": "^1.3.7",
     "simple-mock": "^0"
   },

--- a/test/functional.test.js
+++ b/test/functional.test.js
@@ -1,0 +1,258 @@
+/* Setup */
+var Lab = require('lab');
+var Code = require('code');
+var lab = exports.lab = Lab.script();
+
+var describe = lab.describe;
+var it = lab.it;
+var before = lab.before;
+var beforeEach = lab.beforeEach;
+var after = lab.after;
+var afterEach = lab.afterEach;
+var expect = Code.expect;
+
+/* Modules */
+var msb = require('..');
+var simple = require('simple-mock');
+var mockResponderFactory = require('msb-test-utils/mockResponderFactory');
+
+describe('Requester/Collector', function() {
+  var mockNamespace;
+  var channelManager;
+  var onResponseMock;
+  var onErrorMock;
+  var onEndMock;
+  var mockResponder;
+  var altMockResponder;
+
+  before(function(done) {
+    mockNamespace = 'test:functional';
+
+    channelManager = msb.createChannelManager().configure({
+      brokerAdapter: 'local'
+    });
+
+    done();
+  });
+
+  beforeEach(function(done) {
+    onResponseMock = simple.mock();
+    onErrorMock = simple.mock();
+    onEndMock = simple.mock();
+
+    mockResponder = mockResponderFactory.create(msb, {
+      namespace: mockNamespace
+    }, channelManager);
+
+    altMockResponder = mockResponderFactory.create(msb, {
+      namespace: mockNamespace
+    }, channelManager);
+
+    done();
+  });
+
+  afterEach(function(done) {
+    mockResponder.end();
+    altMockResponder.end();
+    simple.restore();
+    done();
+  });
+
+  describe('with waitForResponses:-1 (default) and waitForResponsesMs:500', function() {
+    var requester;
+
+    beforeEach(function(done) {
+      requester = msb.Requester({
+        namespace: mockNamespace,
+        waitForResponsesMs: 500
+      })
+
+      requester.channelManager = channelManager;
+
+      requester
+      .on('response', onResponseMock)
+      .on('error', onErrorMock)
+      .on('end', onEndMock);
+
+      done();
+    });
+
+    it('will end after the specified timeout', function(done) {
+      requester.publish({});
+
+      setImmediate(function() {
+        expect(onEndMock.callCount).equals(0);
+
+        setTimeout(function() {
+          expect(onEndMock.callCount).equals(1);
+          done();
+        }, 600);
+      });
+    });
+
+    it('will end after an ack-extended timeout', function(done) {
+      mockResponder.respondWith([
+        { type: 'ack', timeoutMs: 1000, responsesRemaining: 1 }
+      ]);
+
+      requester.publish({});
+
+      setImmediate(function() {
+        expect(onEndMock.callCount).equals(0);
+
+        setTimeout(function() {
+          expect(onEndMock.callCount).equals(0);
+        }, 600);
+
+        setTimeout(function() {
+          expect(onEndMock.callCount).equals(1);
+          done();
+        }, 1100);
+      });
+    });
+
+    it('will end after ack-configured response in ack-extended timeout', function(done) {
+      mockResponder.respondWith([
+        { type: 'ack', timeoutMs: 1000, responsesRemaining: 1 },
+        { waitMs: 600, payload: { body: 'within' } },
+        { waitMs: 50, payload: { body: 'after' } }
+      ]);
+
+      requester.publish({});
+
+      setImmediate(function() {
+        expect(onEndMock.callCount).equals(0);
+
+        setTimeout(function() {
+          expect(onEndMock.callCount).equals(0);
+        }, 550);
+
+        setTimeout(function() {
+          expect(onResponseMock.callCount).equals(1)
+          expect(onEndMock.callCount).equals(1);
+          done();
+        }, 700);
+      });
+    });
+  });
+
+  describe('with waitForResponses:2 and waitForResponsesMs:500', function() {
+    var requester;
+
+    beforeEach(function(done) {
+      requester = msb.Requester({
+        namespace: mockNamespace,
+        waitForResponses: 2,
+        waitForResponsesMs: 500
+      })
+
+      requester.channelManager = channelManager;
+
+      requester
+      .on('response', onResponseMock)
+      .on('error', onErrorMock)
+      .on('end', onEndMock);
+
+      done();
+    });
+
+    it('will end after the specified timeout without sufficient ressponses', function(done) {
+      mockResponder.respondWith([
+        { payload: { body: 'within' } },
+        { waitMs: 500, payload: { body: 'after' } }
+      ]);
+
+      requester.publish({});
+
+      setImmediate(function() {
+        expect(onEndMock.callCount).equals(0);
+
+        setTimeout(function() {
+          expect(onResponseMock.callCount).equals(1)
+          expect(onEndMock.callCount).equals(0);
+        }, 100);
+
+        setTimeout(function() {
+          expect(onResponseMock.callCount).equals(1)
+          expect(onEndMock.callCount).equals(1);
+          done();
+        }, 600);
+      });
+    });
+
+    it('will end after configured expected number of responses', function(done) {
+      mockResponder.respondWith([
+        { type: 'ack', responsesRemaining: 1 },
+        { payload: { body: 'within' } },
+        { waitMs: 200, payload: { body: 'within' } }
+      ]);
+
+      requester.publish({});
+
+      setImmediate(function() {
+        expect(onEndMock.callCount).equals(0);
+
+        setTimeout(function() {
+          expect(onResponseMock.callCount).equals(1)
+          expect(onEndMock.callCount).equals(0);
+        }, 100);
+
+        setTimeout(function() {
+          expect(onResponseMock.callCount).equals(2)
+          expect(onEndMock.callCount).equals(1);
+          done();
+        }, 300);
+      });
+    });
+
+    it('will end after expected ack-configured responses in ack-extended timeout', function(done) {
+      mockResponder.respondWith([
+        { type: 'ack', timeoutMs: 1000, responsesRemaining: 3 },
+        { waitMs: 500, payload: { body: 'within' } },
+        { waitMs: 50, payload: { body: 'within' } },
+        { waitMs: 50, payload: { body: 'within' } },
+        { waitMs: 50, payload: { body: 'after' } }
+      ]);
+
+      altMockResponder.respondWith([
+        { waitMs: 50, payload: { body: 'non-acked' } }
+      ]);
+
+      requester.publish({});
+
+      setImmediate(function() {
+        expect(onEndMock.callCount).equals(0);
+
+        setTimeout(function() {
+          expect(onEndMock.callCount).equals(0);
+          expect(onResponseMock.callCount).equals(1);
+        }, 100);
+
+        setTimeout(function() {
+          expect(onResponseMock.callCount).equals(4)
+          expect(onEndMock.callCount).equals(1);
+          done();
+        }, 625);
+      });
+    });
+
+    it('will end after ack-configured responses within same responder\'s ack-extended timeout', function(done) {
+      mockResponder.respondWith([
+        { type: 'ack', timeoutMs: 1000, responsesRemaining: 1 },
+        { waitMs: 600, payload: { body: 'within' } }
+      ]);
+
+      requester.publish({});
+
+      setImmediate(function() {
+        expect(onEndMock.callCount).equals(0);
+
+        setTimeout(function() {
+          expect(onResponseMock.callCount).equals(1)
+          expect(onEndMock.callCount).equals(1);
+          done();
+        }, 625);
+      });
+    });
+  });
+});


### PR DESCRIPTION
This fixes the scenarios where a Requester/Collector does not end immediately after the expected number of responses is reached or an ack-extended timeout is reached during the period beyond the base timeout.

E.g.

For a collector with responseTimeout 2000ms, expected responses default (-1 or not set)
at 100 ack with timeout 5000ms, responsesRemaining 2 for responder B
at 500ms response is received for B
at 2600ms response is received for B
collector should end immediately, it ended at 5000ms.

And...

For a collector with responseTimeout 2000ms, expected responses 2
at 100 ack with timeout 5000ms, responsesRemaining 1 for responder B
at 2600ms response is received for B
collector should end immediately, it ended at 5000ms.
