### PR TITLE
Change how serviceDetails locates package.json when hosted in iisnode on Windows

### DIFF
--- a/lib/support/generateId.js
+++ b/lib/support/generateId.js
@@ -20,6 +20,8 @@ module.exports = function generateId() {
 var maxI = 65536;
 var i = maxI;
 function inc() {
+  /* $lab:coverage:off$ */   //We would have to run generateId() 65536 times to get full coverage on next line
   i = (i - 1) || maxI;
+  /* $lab:coverage:on$ */
   return maxI - i;
 }

--- a/lib/support/serviceDetails.js
+++ b/lib/support/serviceDetails.js
@@ -19,13 +19,34 @@ serviceDetails.instanceId = env.MSB_SERVICE_INSTANCE_ID || require('./generateId
  */
 function _mainPackage() {
   var pkg;
-  _.find(process.mainModule && process.mainModule.paths, function(modulesPath) {
-    var pathToPackage = require('path').resolve(modulesPath, '..', 'package.json');
+  var path = require('path');
+  
+  //When hosting on Windows on IIS in iisnode, process.mainModule isn't the application.
+  //Instead iisnode's interceptor.js is started as main. It does a good job at hiding itself but
+  //unfortunately process.mainModule isn't changed.
+  //So we test if we're on iisnode. There isn't any safe way to do this, so we use hacks
+  // 1. First see if we're using interceptor.js. 
+  // 2. As the user may specify another intercepter we then look if we have any of iisnode's 
+  //    well known env vars that _might_ be set
+  var oniisnode = process.mainModule && process.mainModule.filename && process.mainModule.filename.substr(-14) === 'interceptor.js' ||
+    _.any(_.keys(env), function(envName) { return envName.indexOf('IISNODE_') === 0 }) 
+  
+  //If we're on iisnode we can use the fact that current working directory is set to the application's
+  //root, otherwise we use the paths provided by process.mainModule
+  var possibleLocations = oniisnode 
+    ? [path.resolve(process.cwd(), 'justNeedSomeFileToEndThePath')]
+    : process.mainModule && process.mainModule.paths
+  
+  //Find first location with a package.json file
+  _.find(possibleLocations, function(modulesPath) {
+    var pathToPackage = path.resolve(modulesPath, '..', 'package.json');
     try {
       pkg = require(pathToPackage);
+      return true;
     } catch (e) {
+      // Intentionally left blank
     }
-    return pkg;
   });
+  
   return pkg;
 }

--- a/lib/support/serviceDetails.js
+++ b/lib/support/serviceDetails.js
@@ -20,7 +20,9 @@ function create() {
   * Return the contents of package.json as an object
   * @return {Object}
   */
+  /* $lab:coverage:off$ */
   function _mainPackage() {
+    /* $lab:coverage:on$ */
     var pkg;
     var path = require('path');
     

--- a/lib/support/serviceDetails.js
+++ b/lib/support/serviceDetails.js
@@ -1,52 +1,58 @@
 'use strict';
 var _ = require('lodash');
-var env = process.env;
 
-var serviceDetails = exports;
+function create() { 
+  var env = process.env;
+  var serviceDetails = {};
+  
+  serviceDetails.hostname = require('os').hostname();
+  serviceDetails.ip = require('ip').address();
+  serviceDetails.pid = process.pid;
+  
+  var pkg = _mainPackage();
+  serviceDetails.name = env.MSB_SERVICE_NAME || pkg && pkg.name;
+  serviceDetails.version = env.MSB_SERVICE_VERSION || pkg && pkg.version;
+  serviceDetails.instanceId = env.MSB_SERVICE_INSTANCE_ID || require('./generateId')();
+  
+  return serviceDetails
 
-serviceDetails.hostname = require('os').hostname();
-serviceDetails.ip = require('ip').address();
-serviceDetails.pid = process.pid;
-
-var pkg = _mainPackage();
-serviceDetails.name = env.MSB_SERVICE_NAME || pkg && pkg.name;
-serviceDetails.version = env.MSB_SERVICE_VERSION || pkg && pkg.version;
-serviceDetails.instanceId = env.MSB_SERVICE_INSTANCE_ID || require('./generateId')();
-
-/**
- * Return the contents of package.json as an object
- * @return {Object}
- */
-function _mainPackage() {
-  var pkg;
-  var path = require('path');
-  
-  //When hosting on Windows on IIS in iisnode, process.mainModule isn't the application.
-  //Instead iisnode's interceptor.js is started as main. It does a good job at hiding itself but
-  //unfortunately process.mainModule isn't changed.
-  //So we test if we're on iisnode. There isn't any safe way to do this, so we use hacks
-  // 1. First see if we're using interceptor.js. 
-  // 2. As the user may specify another intercepter we then look if we have any of iisnode's 
-  //    well known env vars that _might_ be set
-  var oniisnode = process.mainModule && process.mainModule.filename && process.mainModule.filename.substr(-14) === 'interceptor.js' ||
-    _.any(_.keys(env), function(envName) { return envName.indexOf('IISNODE_') === 0 }) 
-  
-  //If we're on iisnode we can use the fact that current working directory is set to the application's
-  //root, otherwise we use the paths provided by process.mainModule
-  var possibleLocations = oniisnode 
-    ? [path.resolve(process.cwd(), 'justNeedSomeFileToEndThePath')]
-    : process.mainModule && process.mainModule.paths
-  
-  //Find first location with a package.json file
-  _.find(possibleLocations, function(modulesPath) {
-    var pathToPackage = path.resolve(modulesPath, '..', 'package.json');
-    try {
-      pkg = require(pathToPackage);
-      return true;
-    } catch (e) {
-      // Intentionally left blank
-    }
-  });
-  
-  return pkg;
+  /**
+  * Return the contents of package.json as an object
+  * @return {Object}
+  */
+  function _mainPackage() {
+    var pkg;
+    var path = require('path');
+    
+    //When hosting on Windows on IIS in iisnode, process.mainModule isn't the application.
+    //Instead iisnode's interceptor.js is started as main. It does a good job at hiding itself but
+    //unfortunately process.mainModule isn't changed.
+    //So we test if we're on iisnode. There isn't any safe way to do this, so we use hacks
+    // 1. First see if we're using interceptor.js. 
+    // 2. As the user may specify another interceptor we then look if we have any of iisnode's 
+    //    well known env vars that _might_ be set
+    var oniisnode = process.mainModule && process.mainModule.filename && process.mainModule.filename.substr(-14) === 'interceptor.js' ||
+      _.any(_.keys(env), function(envName) { return envName.indexOf('IISNODE_') === 0 }) 
+    
+    //If we're on iisnode we can use the fact that current working directory is set to the application's
+    //root, otherwise we use the paths provided by process.mainModule
+    var possibleLocations = oniisnode 
+      ? [path.resolve(process.cwd(), 'justNeedSomeFileToEndThePath')]
+      : process.mainModule && process.mainModule.paths
+    
+    //Find first location with a package.json file
+    _.find(possibleLocations, function(modulesPath) {
+      var pathToPackage = path.resolve(modulesPath, '..', 'package.json');
+      try {
+        pkg = require(pathToPackage);
+        return true;
+      } catch (e) {
+        // Intentionally left blank
+      }
+    });
+    
+    return pkg;
+  }
 }
+module.exports = create()
+module.exports._createForTest = create

--- a/test/serviceDetails.test.js
+++ b/test/serviceDetails.test.js
@@ -25,6 +25,11 @@ describe('serviceDetails', function() {
     done();
   });
 
+  afterEach(function(done) {
+    simple.restore();
+    done();
+  });
+
   it('should set serviceDetails dynamically', function(done) {
     simple.mock(require('os'), 'hostname').returnWith('abchost');
     simple.mock(require('ip'), 'address').returnWith('1.2.3.4');
@@ -111,4 +116,30 @@ describe('serviceDetails', function() {
 
     done();
   });
+
+  it('should use package.json from cwd when on iisnode using interceptor.js', function(done) {
+    simple.mock(process, 'mainModule', { filename: 'c:\\Program Files (x86)\\iisnode\\interceptor.js' });
+    simple.mock(process, 'cwd').returnWith(require('path').join(__dirname, 'fixtures'));
+    serviceDetails = require(serviceDetailsModulePath);
+
+    expect(serviceDetails.name).equals('example');
+    expect(serviceDetails.version).equals('1.0.0');
+    expect(serviceDetails.instanceId).length(24);
+
+    done();
+  });
+
+  it('should use package.json from cwd when on iisnode using interceptor.js', function(done) {
+    simple.mock(process, 'mainModule', { filename: 'c:\\Program Files (x86)\\iisnode\\another-interceptor-file.js' });
+    simple.mock(process.env, 'IISNODE_WHATEVER', 'whatever');
+    simple.mock(process, 'cwd').returnWith(require('path').join(__dirname, 'fixtures'));
+    serviceDetails = require(serviceDetailsModulePath);
+
+    expect(serviceDetails.name).equals('example');
+    expect(serviceDetails.version).equals('1.0.0');
+    expect(serviceDetails.instanceId).length(24);
+
+    done();
+  });
+
 });

--- a/test/serviceDetails.test.js
+++ b/test/serviceDetails.test.js
@@ -21,7 +21,6 @@ describe('serviceDetails', function() {
   var serviceDetails;
 
   beforeEach(function(done) {
-    delete(require.cache[serviceDetailsModulePath]);
     done();
   });
 
@@ -34,7 +33,7 @@ describe('serviceDetails', function() {
     simple.mock(require('os'), 'hostname').returnWith('abchost');
     simple.mock(require('ip'), 'address').returnWith('1.2.3.4');
 
-    serviceDetails = require(serviceDetailsModulePath);
+    serviceDetails = require(serviceDetailsModulePath)._createForTest();
 
     expect(serviceDetails.hostname).equals('abchost');
     expect(serviceDetails.ip).equals('1.2.3.4');
@@ -50,7 +49,7 @@ describe('serviceDetails', function() {
   it('should safely handle a lack of mainModule', function(done) {
     simple.mock(process, 'mainModule', undefined);
 
-    serviceDetails = require(serviceDetailsModulePath);
+    serviceDetails = require(serviceDetailsModulePath)._createForTest();
 
     expect(serviceDetails.name).equals(undefined);
     expect(serviceDetails.version).equals(undefined);
@@ -62,7 +61,7 @@ describe('serviceDetails', function() {
   it('should safely handle a missing package.json', function(done) {
     simple.mock(process, 'mainModule', { paths: ['/tmp/etc.js'] });
 
-    serviceDetails = require(serviceDetailsModulePath);
+    serviceDetails = require(serviceDetailsModulePath)._createForTest();
 
     expect(serviceDetails.name).equals(undefined);
     expect(serviceDetails.version).equals(undefined);
@@ -74,7 +73,7 @@ describe('serviceDetails', function() {
   it('should handle a valid package.json', function(done) {
     simple.mock(process, 'mainModule', { paths: [require('path').join(__dirname, 'fixtures', 'package.json')] });
 
-    serviceDetails = require(serviceDetailsModulePath);
+    serviceDetails = require(serviceDetailsModulePath)._createForTest();
 
     expect(serviceDetails.name).equals('example');
     expect(serviceDetails.version).equals('1.0.0');
@@ -92,7 +91,7 @@ describe('serviceDetails', function() {
 
     simple.mock(process, 'mainModule', { paths: [path] });
 
-    serviceDetails = require(serviceDetailsModulePath);
+    serviceDetails = require(serviceDetailsModulePath)._createForTest();
 
     expect(serviceDetails.name).equals(undefined);
     expect(serviceDetails.version).equals(undefined);
@@ -108,7 +107,7 @@ describe('serviceDetails', function() {
     simple.mock(process.env, 'MSB_SERVICE_VERSION', '999');
     simple.mock(process.env, 'MSB_SERVICE_INSTANCE_ID', 'abc123');
 
-    serviceDetails = require(serviceDetailsModulePath);
+    serviceDetails = require(serviceDetailsModulePath)._createForTest();
 
     expect(serviceDetails.name).equals('special-name');
     expect(serviceDetails.version).equals('999');
@@ -120,7 +119,7 @@ describe('serviceDetails', function() {
   it('should use package.json from cwd when on iisnode using interceptor.js', function(done) {
     simple.mock(process, 'mainModule', { filename: 'c:\\Program Files (x86)\\iisnode\\interceptor.js' });
     simple.mock(process, 'cwd').returnWith(require('path').join(__dirname, 'fixtures'));
-    serviceDetails = require(serviceDetailsModulePath);
+    serviceDetails = require(serviceDetailsModulePath)._createForTest();
 
     expect(serviceDetails.name).equals('example');
     expect(serviceDetails.version).equals('1.0.0');
@@ -129,11 +128,11 @@ describe('serviceDetails', function() {
     done();
   });
 
-  it('should use package.json from cwd when on iisnode using interceptor.js', function(done) {
+  it('should use package.json from cwd when on iisnode using something else than interceptor.js', function(done) {
     simple.mock(process, 'mainModule', { filename: 'c:\\Program Files (x86)\\iisnode\\another-interceptor-file.js' });
     simple.mock(process.env, 'IISNODE_WHATEVER', 'whatever');
     simple.mock(process, 'cwd').returnWith(require('path').join(__dirname, 'fixtures'));
-    serviceDetails = require(serviceDetailsModulePath);
+    serviceDetails = require(serviceDetailsModulePath)._createForTest();
 
     expect(serviceDetails.name).equals('example');
     expect(serviceDetails.version).equals('1.0.0');


### PR DESCRIPTION
Fixes #60 **serviceDetails cannot find package.json when hosted in iisnode on Windows**

This PR fixes a problem in Windows.

When hosted on Windows in IIS in iisnode, `process.mainModule` isn't the application's main module. Instead iisnode's `interceptor.js` is started as main, which then loads the application. 

This means `process.mainModule.paths` cannot be used for where to look for `package.json`.

If we're on iisnode we can use the fact that current working directory is set to the application's and we look for `package.json` there.

Unfortunately, there is no safe way to determine if we're on iisnode. To make sure msb properly can detect that we're using iisnode the
any env var that starts with `"IISNODE_"` can be set, for example `IISNODE_HOSTED=true`
#### Code coverage for `serviceDetails.js`

This PR also improves the reported code coverage.
As the `serviceDetails` module was deleted from `require.cache` before each run, lab only reported the last run when doing code coverage analysis.

`serviceDetails.js` was refactored to provide a `_createForTest()` function that creates a new `serviceDetail` object without caching anything between
calls. 
`serviceDetails.js` still provides a default serviceDetail object for normal usage.
