### PR TITLE
Make it possible to specify amqp settings when running tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,3 +88,45 @@ If you want to run tests without code style check:
 If you just want to run with automatic restarting on a file change (no linting):
 
     $ npm run test-watch
+
+The integration tests requires access to an AMQP instance, for example RabbitMQ, by default it expect it to be installed locally as it looks for localhost:5672.
+
+###### RabbitMQ in Docker
+[RabbitMQ](https://www.rabbitmq.com/) can be installed locally, or hosted in [Docker](https://www.docker.com/). 
+
+To start an instance in docker:
+
+```
+docker run -d -p 5672:5672 --hostname msbRabbitMQ --name rabbitmq rabbitmq:3
+```
+
+To find out the ip address of the docker machine:
+
+```
+docker-machine ip default
+```
+
+Set the env variable `MSB_BROKER_HOST` to the ip address and run the test. 
+
+On Linux and OSX:
+
+```
+MSB_BROKER_HOST=192.168.99.100 npm run test
+``` 
+
+
+
+###### Display AMQP connection info when running tests
+Set the env variables `DEBUG=amqp*` and `AMQP=3`.
+
+On Linux and OSX:
+
+```
+DEBUG=amqp* AMQP=3 node_modules/.bin/lab --verbose
+``` 
+
+... or using custom amqp instance:
+
+```
+MSB_BROKER_HOST=192.168.99.100 DEBUG=amqp* AMQP=3 node_modules/.bin/lab --verbose
+``` 

--- a/test/adapters.amqp.publisher.test.js
+++ b/test/adapters.amqp.publisher.test.js
@@ -17,7 +17,7 @@ var simple = require('simple-mock');
 var msb = require('..');
 var AMQPPublisherAdapter = require('../lib/adapters/amqp/publisher').AMQPPublisherAdapter;
 var AMQP = require('amqp-coffee');
-var config = require('../lib/config');
+var config = require('../lib/config').create();
 
 describe('AMQPPublisherAdapter', function() {
   var connection;
@@ -27,7 +27,7 @@ describe('AMQPPublisherAdapter', function() {
   describe('publish()', function() {
 
     before(function(done) {
-      connection = new AMQP({});
+      connection = new AMQP(config.amqp);
       publisher = new AMQPPublisherAdapter(null, connection);
       exchange = {};
       done();

--- a/test/support/amqpPublisher.js
+++ b/test/support/amqpPublisher.js
@@ -2,9 +2,9 @@ var _ = require('lodash');
 var async = require('async');
 var EventEmitter = require('events').EventEmitter;
 var AMQP = require('amqp-coffee');
-
+var config = require('../../lib/config').create()
 exports.create = function(topic, cb) {
-  var connection = new AMQP({});
+  var connection = new AMQP(config.amqp);
 
   connection.once('ready', function() {
     var publisher = {


### PR DESCRIPTION
This PR makes it possible to specify the normal AMQP related env vars, such as `MSB_BROKER_HOST` when running tests, in order to be able to run integration tests against a AMQP instance not installed on localhost.

Also updates CONTRIBUTING.md with info on how to run the tests against a RabbitMQ instance hosted in Docker.
