### PR TITLE
Set host "unknown" on configured incorrectly host

### DIFF
--- a/lib/support/serviceDetails.js
+++ b/lib/support/serviceDetails.js
@@ -4,8 +4,12 @@ var env = process.env;
 
 var serviceDetails = exports;
 
-serviceDetails.hostname = require('os').hostname();
-serviceDetails.ip = require('ip').address();
+try {
+  serviceDetails.hostname = require('os').hostname();
+  serviceDetails.ip = require('ip').address();
+} catch(e) {
+  serviceDetails.hostname = 'unknown'
+}
 serviceDetails.pid = process.pid;
 
 var pkg = _mainPackage();

--- a/test/serviceDetails.test.js
+++ b/test/serviceDetails.test.js
@@ -42,6 +42,21 @@ describe('serviceDetails', function() {
     done();
   });
 
+  it('should set host "unknown" on configured incorrectly host', function(done) {
+    simple.mock(require('os'), 'hostname').throwWith(new Error());
+
+    serviceDetails = require(serviceDetailsModulePath);
+
+    expect(serviceDetails.hostname).equals('unknown');
+    expect(serviceDetails.pid).equals(process.pid);
+
+    expect(serviceDetails.name).equals('lab');
+    expect(!!serviceDetails.version.match(/\d+\.\d+\.\d+/)).true();
+    expect(serviceDetails.instanceId).length(24);
+
+    done();
+  });
+
   it('should safely handle a lack of mainModule', function(done) {
     simple.mock(process, 'mainModule', undefined);
 


### PR DESCRIPTION
If a host is configured incorrectly, msb-node unable to resolve host name and throws UnknownHostException exeption. The "unknown" value should be set as a host name instead of exception throwing in that case.
