### PR TITLE
Fix 1.x crash when process pid is larger than 65535

### DIFF
--- a/lib/support/generateId.js
+++ b/lib/support/generateId.js
@@ -7,10 +7,10 @@ var buf = new Buffer(12);
 buf[4] = INSTANCE_ID[0];
 buf[5] = INSTANCE_ID[1];
 
-buf.writeUInt16BE(process.pid, 6, true);
+buf.writeUInt16BE(process.pid & 0xFFFF, 6);
 
 module.exports = function generateId() {
-  buf.writeUInt32BE(Math.floor(Date.now() / 1000) - BASE_UNIX_DATE, 0, true);
+  buf.writeUInt32BE((Math.floor(Date.now() / 1000) - BASE_UNIX_DATE) & 0xFFFFFFFF, 0);
   buf.writeUInt16BE(inc(), 8);
   buf.writeUInt8(Math.floor(Math.random() * 256), 10);
   buf.writeUInt8(Math.floor(Math.random() * 256), 11);


### PR DESCRIPTION
Node 10 removes noAssert from buffer.write functions

https://github.com/nodejs/node/commit/e8bb1f35df